### PR TITLE
Updates timestamp format to something that is recognizable.

### DIFF
--- a/frontend/imports/ui/client/helpers.js
+++ b/frontend/imports/ui/client/helpers.js
@@ -184,7 +184,7 @@ Template.registerHelper('timestampToString', (ts, inSeconds, short) => {
   if (ts) {
     const momentFromTimestamp = (inSeconds === true) ? moment.unix(ts) : moment.unix(ts / 1000);
     if (short === true) {
-      timestampStr = momentFromTimestamp.format('DD.MM-HH:mm');
+      timestampStr = momentFromTimestamp.format('YYYY-MM-DDTHH:mm:ss') + 'Z';
     } else {
       timestampStr = momentFromTimestamp.format();
     }


### PR DESCRIPTION
My main reason for opening this PR is as a means of starting discussion around the usability of non-standard time formatting, and this proposed change is really just a straw-man for that discussion.

I have never seen `DD.MM-HH:mm:ss` before, and actually understanding what timestamp this was in the UI required me to go dig into the source code.  I see that ISO8601 is being used for the "long" format, though it is unclear why there is a desire to save ~10 characters here.  This changes it to a *slightly* shorter form of ISO8601 than what moment uses (`Z` timezone).

As a developer/user (who has seen a lot of timestamp formats in my day), I was *super* confused by the previous format.

Other options would be `YY-MM-DD HH:mm:ss`, which is ~3 characters longer than original and more clear and closely aligned with ISO8601, though it leaves out the time zone, which I believe to be critical as the time is in UTC if I am not mistaken, rather than user's local clock.  Also, it truncates the YY to two digits which makes it difficult to distinguish from `DD` for the next ~15 years.